### PR TITLE
Add admin mode: teacher-only registration with JSON credentials

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher-only sign up and unregister flows for activities
+- Teacher login backed by a JSON credentials file
 
 ## Getting Started
 
@@ -21,7 +22,9 @@ A super simple FastAPI application that allows students to view and sign up for 
    python app.py
    ```
 
-3. Open your browser and go to:
+3. Teacher credentials are stored in [src/teachers.json](src/teachers.json). Example accounts included for local testing are `ms-johnson` / `faculty123` and `mr-lee` / `advising456`.
+
+4. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
 
@@ -30,7 +33,11 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/auth/session`                                                   | Get the current teacher login state                                 |
+| POST   | `/auth/login`                                                     | Log in a teacher and set the session cookie                         |
+| POST   | `/auth/logout`                                                    | Clear the teacher session cookie                                    |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student for an activity as a teacher                     |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity as a teacher               |
 
 ## Data Model
 
@@ -48,3 +55,5 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+Teacher credentials are stored in a checked-in JSON file for this exercise, matching the constraint in issue #5.

--- a/src/app.py
+++ b/src/app.py
@@ -5,19 +5,89 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import base64
+import hashlib
+import hmac
+import json
 import os
 from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
-# Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+SESSION_COOKIE_NAME = "admin_session"
+SESSION_SECRET = "mergington-high-school-admin-mode"
+teachers_file = current_dir / "teachers.json"
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teachers() -> dict[str, str]:
+    with teachers_file.open("r", encoding="utf-8") as file:
+        teachers = json.load(file)
+
+    if not isinstance(teachers, dict):
+        raise RuntimeError("teachers.json must contain a username/password object")
+
+    return teachers
+
+
+teacher_credentials = load_teachers()
+
+
+def create_session_token(username: str) -> str:
+    signature = hmac.new(
+        SESSION_SECRET.encode("utf-8"),
+        username.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    raw_token = f"{username}:{signature}"
+    return base64.urlsafe_b64encode(raw_token.encode("utf-8")).decode("utf-8")
+
+
+def get_authenticated_teacher(request: Request) -> str | None:
+    token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not token:
+        return None
+
+    try:
+        decoded_token = base64.urlsafe_b64decode(token.encode("utf-8")).decode("utf-8")
+        username, provided_signature = decoded_token.split(":", 1)
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+    expected_signature = hmac.new(
+        SESSION_SECRET.encode("utf-8"),
+        username.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(provided_signature, expected_signature):
+        return None
+
+    if username not in teacher_credentials:
+        return None
+
+    return username
+
+
+def require_teacher(request: Request) -> str:
+    username = get_authenticated_teacher(request)
+    if not username:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+    return username
 
 # In-memory activity database
 activities = {
@@ -83,20 +153,56 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.get("/auth/session")
+def get_session(request: Request):
+    username = get_authenticated_teacher(request)
+    return {
+        "authenticated": bool(username),
+        "username": username,
+    }
+
+
+@app.post("/auth/login")
+def login(login_request: LoginRequest, response: Response):
+    expected_password = teacher_credentials.get(login_request.username)
+    if not expected_password or not hmac.compare_digest(expected_password, login_request.password):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=create_session_token(login_request.username),
+        httponly=True,
+        samesite="lax",
+        max_age=8 * 60 * 60,
+    )
+    return {"message": f"Logged in as {login_request.username}", "username": login_request.username}
+
+
+@app.post("/auth/logout")
+def logout(response: Response):
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    return {"message": "Logged out"}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, request: Request):
     """Sign up a student for an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is already full")
 
     # Validate student is not already signed up
     if email in activity["participants"]:
@@ -111,8 +217,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, request: Request):
     """Unregister a student from an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,75 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupHelpText = document.getElementById("signup-help-text");
+  const accountButton = document.getElementById("account-button");
+  const accountButtonLabel = document.getElementById("account-button-label");
+  const accountPanel = document.getElementById("account-panel");
+  const sessionStatus = document.getElementById("session-status");
+  const showLoginButton = document.getElementById("show-login-button");
+  const logoutButton = document.getElementById("logout-button");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModalButton = document.getElementById("close-login-modal");
+  const loginForm = document.getElementById("login-form");
+
+  let session = {
+    authenticated: false,
+    username: null,
+  };
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+    document.getElementById("username").focus();
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  }
+
+  function renderSessionState() {
+    const canManageRegistrations = session.authenticated;
+
+    signupForm.querySelectorAll("input, select, button").forEach((element) => {
+      element.disabled = !canManageRegistrations;
+    });
+
+    if (canManageRegistrations) {
+      accountButtonLabel.textContent = session.username;
+      sessionStatus.textContent = `Logged in as ${session.username}. You can register and unregister students.`;
+      signupHelpText.textContent = "Teacher mode is active. Registration changes are enabled.";
+      showLoginButton.classList.add("hidden");
+      logoutButton.classList.remove("hidden");
+    } else {
+      accountButtonLabel.textContent = "Account";
+      sessionStatus.textContent = "Students can browse activities. Teachers can log in to manage registrations.";
+      signupHelpText.textContent = "Teacher login is required to register or unregister students.";
+      showLoginButton.classList.remove("hidden");
+      logoutButton.classList.add("hidden");
+    }
+  }
+
+  async function refreshSession() {
+    try {
+      const response = await fetch("/auth/session");
+      session = await response.json();
+      renderSessionState();
+    } catch (error) {
+      console.error("Error loading session:", error);
+      session = { authenticated: false, username: null };
+      renderSessionState();
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +99,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn ${
+                        session.authenticated ? "" : "hidden"
+                      }" data-activity="${name}" data-email="${email}" aria-label="Remove ${email} from ${name}">❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +140,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!session.authenticated) {
+      showMessage("Teacher login required", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -86,26 +162,15 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +178,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!session.authenticated) {
+      showMessage("Teacher login required", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -130,31 +200,92 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  accountButton.addEventListener("click", () => {
+    const isExpanded = accountButton.getAttribute("aria-expanded") === "true";
+    accountButton.setAttribute("aria-expanded", String(!isExpanded));
+    accountPanel.classList.toggle("hidden");
+  });
+
+  showLoginButton.addEventListener("click", () => {
+    accountPanel.classList.add("hidden");
+    accountButton.setAttribute("aria-expanded", "false");
+    openLoginModal();
+  });
+
+  closeLoginModalButton.addEventListener("click", closeLoginModal);
+
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      closeLoginModal();
+      showMessage(result.message, "success");
+      await refreshSession();
+      fetchActivities();
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", { method: "POST" });
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+      }
+    } catch (error) {
+      showMessage("Failed to log out cleanly.", "error");
+      console.error("Error logging out:", error);
+    } finally {
+      session = { authenticated: false, username: null };
+      renderSessionState();
+      fetchActivities();
+      accountPanel.classList.add("hidden");
+      accountButton.setAttribute("aria-expanded", "false");
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  refreshSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,23 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-bar">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="account-menu">
+          <button id="account-button" class="account-button" type="button" aria-expanded="false" aria-controls="account-panel">
+            <span class="account-icon" aria-hidden="true">👤</span>
+            <span id="account-button-label">Account</span>
+          </button>
+          <div id="account-panel" class="account-panel hidden">
+            <p id="session-status" class="session-status">Students can browse activities. Teachers can log in to manage registrations.</p>
+            <button id="show-login-button" type="button">Teacher Login</button>
+            <button id="logout-button" class="secondary-button hidden" type="button">Log Out</button>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -22,7 +37,10 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Register a Student</h3>
+        <p id="signup-help-text" class="helper-text">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +58,28 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 id="login-title">Teacher Login</h3>
+          <button id="close-login-modal" class="icon-button" type="button" aria-label="Close login dialog">×</button>
+        </div>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required autocomplete="current-password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Log In</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2026 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,7 +16,6 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
@@ -24,8 +23,53 @@ header {
   border-radius: 5px;
 }
 
+.header-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 20px;
+}
+
 header h1 {
   margin-bottom: 10px;
+}
+
+.account-menu {
+  position: relative;
+}
+
+.account-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background-color: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.account-button:hover {
+  background-color: rgba(255, 255, 255, 0.22);
+}
+
+.account-icon {
+  font-size: 18px;
+}
+
+.account-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 280px;
+  background-color: white;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  padding: 16px;
+  z-index: 10;
+}
+
+.session-status {
+  margin-bottom: 12px;
 }
 
 main {
@@ -125,6 +169,11 @@ section h3 {
   background-color: #ffebee;
 }
 
+.helper-text {
+  margin-bottom: 15px;
+  color: #555;
+}
+
 .participants-section p {
   color: #777;
   font-style: italic;
@@ -164,6 +213,59 @@ button:hover {
   background-color: #3949ab;
 }
 
+.secondary-button {
+  background-color: #eceff1;
+  color: #1a237e;
+}
+
+.secondary-button:hover {
+  background-color: #dfe5e8;
+}
+
+.icon-button {
+  background: none;
+  color: #1a237e;
+  font-size: 28px;
+  line-height: 1;
+  padding: 0;
+}
+
+.icon-button:hover {
+  background: none;
+  color: #3949ab;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(26, 35, 126, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.22);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -197,4 +299,19 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+@media (max-width: 767px) {
+  .header-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .account-menu {
+    align-self: flex-end;
+  }
+
+  .account-panel {
+    width: min(280px, calc(100vw - 40px));
+  }
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "ms-johnson": "faculty123",
+  "mr-lee": "advising456"
+}


### PR DESCRIPTION
## Summary

Fixes #5 by implementing teacher-only registration and unregistration workflows.

## Changes

- **Backend authentication**: Added HMAC-signed session cookies that validate against teacher credentials stored in `src/teachers.json`
- **Protected endpoints**: Both `/activities/{activity}/signup` and `/activities/{activity}/unregister` now require valid teacher login
- **Frontend UI**: Added account dropdown (top-right) with login/logout modal for teacher access control
- **User experience**: Registration form is disabled and clearly labeled when no teacher is logged in
- **Documentation**: Updated README with new auth endpoints and usage examples

## How to Test

1. Run the app (`python src/app.py`)
2. Attempt to register a student without logging in → should get 401 error
3. Click the 👤 Account button, then "Teacher Login"
4. Use credentials: `ms-johnson` / `faculty123` or `mr-lee` / `advising456`
5. After login, the registration form becomes active
6. Register a student → should succeed and appear in the participant list
7. Click Log Out → registration form is disabled again

## Notes

- Teacher credentials are stored in a JSON file checked into the repo per issue #5's constraint
- Session tokens use HMAC-SHA256 with a hard-coded secret (suitable for local/exercise use only)
- Activity visibility remains public; only registration changes require authentication